### PR TITLE
removed size attribute on citation/csl text fields embedded in a table

### DIFF
--- a/citation/csl/csl.module
+++ b/citation/csl/csl.module
@@ -77,10 +77,12 @@ function csl_manage(array &$form_state) {
     '#tree' => FALSE,
     'name' => array(
       '#type' => 'textfield',
+      '#size' => NULL,
       '#title' => 'Name',
     ),
     'file' => array(
       '#type' => 'file',
+      '#size' => NULL,
       '#title' => t('Upload A CSL Style'),
     ),
     'add' => array(


### PR DESCRIPTION
This helps aid responsive breakdown as it stops the fields from extending beyond the viewport. 
